### PR TITLE
test

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -63,7 +63,8 @@ func Default() UserFeatures {
 			ScaleToZeroOnDelete:       true,
 		},
 		Storage: StorageFeatures{
-			DataPlaneAvailable: true,
+			DataPlaneAvailable:           true,
+			DataPlaneAuthAnyScopeEnabled: false,
 		},
 		Subscription: SubscriptionFeatures{
 			PreventCancellationOnDestroy: false,

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -88,7 +88,8 @@ type AppConfigurationFeatures struct {
 }
 
 type StorageFeatures struct {
-	DataPlaneAvailable bool
+	DataPlaneAvailable           bool
+	DataPlaneAuthAnyScopeEnabled bool
 }
 
 type SubscriptionFeatures struct {

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -315,6 +315,11 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 						Optional: true,
 						Default:  true,
 					},
+					"data_plane_auth_any_scope_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
 				},
 			},
 		},
@@ -649,6 +654,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			storageRaw := items[0].(map[string]interface{})
 			if v, ok := storageRaw["data_plane_available"]; ok {
 				featuresMap.Storage.DataPlaneAvailable = v.(bool)
+			}
+			if v, ok := storageRaw["data_plane_auth_any_scope_enabled"]; ok {
+				featuresMap.Storage.DataPlaneAuthAnyScopeEnabled = v.(bool)
 			}
 		}
 	}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -75,7 +75,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: true,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:           true,
+					DataPlaneAuthAnyScopeEnabled: false,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: false,
@@ -168,7 +169,8 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"storage": []interface{}{
 						map[string]interface{}{
-							"data_plane_available": true,
+							"data_plane_available":              true,
+							"data_plane_auth_any_scope_enabled": true,
 						},
 					},
 					"subscription": []interface{}{
@@ -262,7 +264,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: true,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:           true,
+					DataPlaneAuthAnyScopeEnabled: true,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: true,
@@ -369,7 +372,8 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"storage": []interface{}{
 						map[string]interface{}{
-							"data_plane_available": false,
+							"data_plane_available":              false,
+							"data_plane_auth_any_scope_enabled": false,
 						},
 					},
 					"subscription": []interface{}{
@@ -463,7 +467,8 @@ func TestExpandFeatures(t *testing.T) {
 					RecoverSoftDeletedBackupProtectedVM: false,
 				},
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: false,
+					DataPlaneAvailable:           false,
+					DataPlaneAuthAnyScopeEnabled: false,
 				},
 				Subscription: features.SubscriptionFeatures{
 					PreventCancellationOnDestroy: false,
@@ -1498,7 +1503,8 @@ func TestExpandFeaturesStorage(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: true,
+					DataPlaneAvailable:           true,
+					DataPlaneAuthAnyScopeEnabled: false,
 				},
 			},
 		},
@@ -1515,7 +1521,26 @@ func TestExpandFeaturesStorage(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				Storage: features.StorageFeatures{
-					DataPlaneAvailable: false,
+					DataPlaneAvailable:           false,
+					DataPlaneAuthAnyScopeEnabled: false,
+				},
+			},
+		},
+		{
+			Name: "Storage Data Plane Auth with any scope is Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"storage": []interface{}{
+						map[string]interface{}{
+							"data_plane_auth_any_scope_enabled": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				Storage: features.StorageFeatures{
+					DataPlaneAvailable:           true,
+					DataPlaneAuthAnyScopeEnabled: true,
 				},
 			},
 		},

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -420,6 +420,10 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			if !feature[0].DataPlaneAvailable.IsNull() && !feature[0].DataPlaneAvailable.IsUnknown() {
 				f.Storage.DataPlaneAvailable = feature[0].DataPlaneAvailable.ValueBool()
 			}
+			f.Storage.DataPlaneAuthAnyScopeEnabled = false
+			if !feature[0].DataPlaneAuthAnyScopeEnabled.IsNull() && !feature[0].DataPlaneAuthAnyScopeEnabled.IsUnknown() {
+				f.Storage.DataPlaneAuthAnyScopeEnabled = feature[0].DataPlaneAuthAnyScopeEnabled.ValueBool()
+			}
 		}
 
 		if !features.Subscription.IsNull() && !features.Subscription.IsUnknown() {

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -289,7 +289,8 @@ func defaultFeaturesList() types.List {
 	managedDiskList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(ManagedDiskAttributes), []attr.Value{managedDisk})
 
 	storage, _ := basetypes.NewObjectValueFrom(context.Background(), StorageAttributes, map[string]attr.Value{
-		"data_plane_available": basetypes.NewBoolNull(),
+		"data_plane_available":              basetypes.NewBoolNull(),
+		"data_plane_auth_any_scope_enabled": basetypes.NewBoolNull(),
 	})
 	storageList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(StorageAttributes), []attr.Value{storage})
 

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -212,11 +212,13 @@ var ManagedDiskAttributes = map[string]attr.Type{
 }
 
 type Storage struct {
-	DataPlaneAvailable types.Bool `tfsdk:"data_plane_available"`
+	DataPlaneAvailable           types.Bool `tfsdk:"data_plane_available"`
+	DataPlaneAuthAnyScopeEnabled types.Bool `tfsdk:"data_plane_auth_any_scope_enabled"`
 }
 
 var StorageAttributes = map[string]attr.Type{
-	"data_plane_available": types.BoolType,
+	"data_plane_available":              types.BoolType,
+	"data_plane_auth_any_scope_enabled": types.BoolType,
 }
 
 type Subscription struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -421,6 +421,9 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 									"data_plane_available": schema.BoolAttribute{
 										Optional: true,
 									},
+									"data_plane_auth_any_scope_enabled": schema.BoolAttribute{
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/internal/services/storage/client/client.go
+++ b/internal/services/storage/client/client.go
@@ -31,7 +31,8 @@ type Client struct {
 	SyncServerEndpointsClient  *serverendpointresource.ServerEndpointResourceClient
 	SyncServiceClient          *storagesyncservicesresource.StorageSyncServicesResourceClient
 
-	authConfigForAzureAD *auth.Credentials
+	authConfigForAzureAD      *auth.Credentials
+	aadAuthResourceIdentifier string
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -95,6 +96,11 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 
 	if o.StorageUseAzureAD {
 		client.authConfigForAzureAD = o.AuthConfig
+	}
+
+	if o.Features.Storage.DataPlaneAuthAnyScopeEnabled {
+		// See: https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory#microsoft-authentication-library-msal
+		client.aadAuthResourceIdentifier = "https://storage.azure.com"
 	}
 
 	return &client, nil

--- a/internal/services/storage/client/data_plane.go
+++ b/internal/services/storage/client/data_plane.go
@@ -46,7 +46,12 @@ func (Client) DataPlaneOperationSupportingOnlySharedKeyAuth() DataPlaneOperation
 
 func (c Client) configureDataPlane(ctx context.Context, clientName, resourceIdentifier string, baseClient client.BaseClient, account AccountDetails, operation DataPlaneOperation) error {
 	if operation.SupportsAadAuthentication && c.authConfigForAzureAD != nil {
-		api := c.authConfigForAzureAD.Environment.Storage.WithResourceIdentifier(resourceIdentifier)
+		rid := c.aadAuthResourceIdentifier
+		if rid == "" {
+			rid = resourceIdentifier
+		}
+		api := c.authConfigForAzureAD.Environment.Storage.WithResourceIdentifier(rid)
+
 		storageAuth, err := auth.NewAuthorizerFromCredentials(ctx, *c.authConfigForAzureAD, api)
 		if err != nil {
 			return fmt.Errorf("unable to build authorizer for Storage API: %+v", err)

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -89,6 +89,11 @@ provider "azurerm" {
       recover_soft_deleted_backup_protected_vm = true
     }
 
+    storage {
+      data_plane_available              = true
+      data_plane_auth_any_scope_enabled = false
+    }
+
     subscription {
       prevent_cancellation_on_destroy = false
     }
@@ -267,6 +272,13 @@ The `resource_group` block supports the following:
 The `recovery_services_vault` block supports the following:
 
 * `recover_soft_deleted_backup_protected_vm` - (Optional) Should the `azurerm_backup_protected_vm` resource recover a Soft-Deleted protected VM? Defaults to `false`.
+
+---
+
+The `storage` block supports the following:
+
+* `data_plane_available` - (Optional) Should the `azurerm_storage_account` resource reach to the data plane endpoints during creation? Defaults to `true`.
+* `data_plane_auth_any_scope_enabled` - (Optional) Should the storage data plane client that supports AAD auth (enabled via the provider level attribute `storage_use_azuread`) request the access token using the resource identifier of `https://storage.azure.com` instead of the per-resource resource identifier? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
This feature allows the user to control when the storage data plane client (AAD supported) to request access token, whether to use the per-resource resource identifier or the "any scope" resource identifier (i.e. "https://storage.azure.com") (See: https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory#microsoft-authentication-library-msal).

This is useful when the users are running Terraform under cloudshell (or maybe ACA) when auth via MSI. In that case, the MSI endpoint doesn't support the per-resource resource identifier, only the "any scope" identifier will work.

Meanwhile, the feature document is added, together with the previously added `data_plane_available`. I'm not sure if it wasn't added on purpose, if yes I'll remove it.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
